### PR TITLE
feat: add turnstile token verifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ DB_PASSWORD=postgres
 DB_NAME=relief
 DB_SSLMODE=require
 PORT=8080
+TURNSTILE_SECRET_KEY=foobarbaz
+TURNSTILE_API_URL=https://challenges.cloudflare.com/turnstile/v0/siteverify
+VERIFY_TURNSTILE=true

--- a/internal/middleware/turnstile_verifier.go
+++ b/internal/middleware/turnstile_verifier.go
@@ -13,6 +13,11 @@ func TurnstileVerifier() gin.HandlerFunc {
 	verifier := turnstile.NewTokenVerifier(os.Getenv("TURNSTILE_SECRET_KEY"))
 
 	return func(c *gin.Context) {
+		if os.Getenv("VERIFY_TURNSTILE") == "false" {
+			c.Next()
+			return
+		}
+
 		token := c.GetHeader("X-ReCaptcha-Token")
 		if token == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "ReCaptcha token is required"})

--- a/internal/middleware/turnstile_verifier.go
+++ b/internal/middleware/turnstile_verifier.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+
+	"guangfu250923/internal/turnstile"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TurnstileVerifier() gin.HandlerFunc {
+	verifier := turnstile.NewTokenVerifier(os.Getenv("TURNSTILE_SECRET_KEY"))
+
+	return func(c *gin.Context) {
+		token := c.GetHeader("X-ReCaptcha-Token")
+		if token == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ReCaptcha token is required"})
+			c.Abort()
+			return
+		}
+
+		success, err := verifier.Verify(token)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to verify token" + err.Error()})
+			c.Abort()
+			return
+		}
+
+		if !success {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid token"})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/middleware/turnstile_verifier.go
+++ b/internal/middleware/turnstile_verifier.go
@@ -3,37 +3,67 @@ package middleware
 import (
 	"net/http"
 	"os"
+	"strings"
 
 	"guangfu250923/internal/turnstile"
 
 	"github.com/gin-gonic/gin"
 )
 
+type tokenRequest struct {
+	CFTurnstileResponse string `json:"cf-turnstile-response"`
+}
+
+func setupVerifier() turnstile.TokenVerifier {
+	secretKey := os.Getenv("TURNSTILE_SECRET_KEY")
+	if !strings.EqualFold(os.Getenv("VERIFY_TURNSTILE"), "true") || secretKey == "" {
+		return nil
+	}
+
+	return turnstile.NewTokenVerifier(turnstile.NewTokenVerifierOptions{
+		APIURL:    os.Getenv("TURNSTILE_API_URL"),
+		SecretKey: secretKey,
+	})
+}
+
 func TurnstileVerifier() gin.HandlerFunc {
-	verifier := turnstile.NewTokenVerifier(os.Getenv("TURNSTILE_SECRET_KEY"))
+	verifier := setupVerifier()
 
 	return func(c *gin.Context) {
-		if os.Getenv("VERIFY_TURNSTILE") == "false" {
+		// if verifier is not setup, just proceed
+		if verifier == nil {
 			c.Next()
 			return
 		}
 
-		token := c.GetHeader("X-ReCaptcha-Token")
-		if token == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "ReCaptcha token is required"})
+		var in tokenRequest
+		if err := c.ShouldBindBodyWithJSON(&in); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			c.Abort()
 			return
 		}
 
-		success, err := verifier.Verify(token)
+		token := in.CFTurnstileResponse
+		if token == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "blocked", "reason": "turnstile token is required"})
+			c.Abort()
+			return
+		}
+
+		success, err := verifier.Verify(turnstile.VerifyOptions{
+			Token: token,
+			// TODO: should extract the clientIP function to some utils package
+			RemoteIP: c.ClientIP(),
+		})
+
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to verify token" + err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "blocked", "reason": "failed to verify turnstile token"})
 			c.Abort()
 			return
 		}
 
 		if !success {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid token"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "blocked", "reason": "invalid turnstile token"})
 			c.Abort()
 			return
 		}

--- a/internal/turnstile/main.go
+++ b/internal/turnstile/main.go
@@ -1,0 +1,75 @@
+package turnstile
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const turnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+type TokenVerifier interface {
+	Verify(token string) (bool, error)
+}
+
+type TokenVerifierImpl struct {
+	secretKey string
+	client    *http.Client
+}
+
+type verifyRequest struct {
+	Secret   string `json:"secret"`
+	Response string `json:"response"`
+}
+
+type verifyResponse struct {
+	Success     bool     `json:"success"`
+	ChallengeTS string   `json:"challenge_ts,omitempty"`
+	Hostname    string   `json:"hostname,omitempty"`
+	ErrorCodes  []string `json:"error-codes,omitempty"`
+	Action      string   `json:"action,omitempty"`
+}
+
+func NewTokenVerifier(secretKey string) TokenVerifier {
+	return &TokenVerifierImpl{
+		secretKey: secretKey,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (v *TokenVerifierImpl) Verify(token string) (bool, error) {
+	if token == "" {
+		return false, fmt.Errorf("token is empty")
+	}
+
+	reqBody := verifyRequest{
+		Secret:   v.secretKey,
+		Response: token,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := v.client.Post(turnstileVerifyURL, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return false, fmt.Errorf("failed to send verification request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var verifyResp verifyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&verifyResp); err != nil {
+		return false, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return verifyResp.Success, nil
+}


### PR DESCRIPTION
## Description
This pull request introduces Turnstile token verification to the application, adding middleware for validating incoming requests and a reusable verifier implementation. The changes are grouped into middleware integration and core verification logic.

**Middleware integration:**

* Added `TurnstileVerifier` middleware in `internal/middleware/turnstile_verifier.go` to check for a valid Turnstile token in the `X-ReCaptcha-Token` header, conditionally enforce verification based on the `VERIFY_TURNSTILE` environment variable, and return appropriate error responses for missing or invalid tokens.

**Core verification logic:**

* Implemented the `TokenVerifier` interface and its concrete `TokenVerifierImpl` in `internal/turnstile/main.go`, which handles sending token verification requests to Cloudflare's Turnstile API and parsing the response.
* Added helper types and methods in `internal/turnstile/main.go` for request/response payloads, error handling, and HTTP client configuration.

## Reference
https://developers.cloudflare.com/turnstile/get-started/server-side-validation/