### PR TITLE
feat: add valid_pin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ PORT=8080
 TURNSTILE_SECRET_KEY=foobarbaz
 TURNSTILE_API_URL=https://challenges.cloudflare.com/turnstile/v0/siteverify
 VERIFY_TURNSTILE=true
+# Enable PIN verification for human_resources PATCH updates (true/false)
+VERIFY_HR_PIN=false
+# Enable PIN verification for supplies PATCH updates (true/false)
+VERIFY_SUPPLY_PIN=false

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -239,6 +239,8 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
             urgent_requests int,
             medical_requests int
         )`,
+		// Add valid_pin to human_resources for edit verification (6-digit pin). Keep nullable for backward compatibility; app enforces on create/patch.
+		`alter table if exists human_resources add column if not exists valid_pin text`,
 		// Relax NOT NULL if previously set
 		`do $$ begin
         perform 1 from information_schema.columns where table_name='human_resources' and column_name='phone' and is_nullable='NO';
@@ -280,6 +282,7 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
             created_at timestamptz not null default now(),
             updated_at timestamptz not null default now()
         )`,
+		`alter table if exists supplies add column if not exists valid_pin text`,
 		`create index if not exists idx_supplies_updated_at on supplies(updated_at)`,
 		/* Renamed to supply_items (previously 'suppily_items') */
 		`create table if not exists supply_items (

--- a/internal/handlers/util.go
+++ b/internal/handlers/util.go
@@ -30,13 +30,13 @@ func GeneratePin(length int) string {
 	if length <= 0 {
 		length = 6
 	}
-	const digits = "0123456789"
+	const digits = "123456789"
 	res := make([]byte, length)
 	for i := 0; i < length; i++ {
 		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(digits))))
 		if err != nil {
-			// fallback: deterministic but unlikely; just use '0'
-			res[i] = '0'
+			// fallback: deterministic but unlikely; just use '1'
+			res[i] = '1'
 			continue
 		}
 		res[i] = digits[n.Int64()]
@@ -50,7 +50,7 @@ func isValidPin6(s *string) bool {
 		return false
 	}
 	for i := 0; i < 6; i++ {
-		if (*s)[i] < '0' || (*s)[i] > '9' {
+		if (*s)[i] < '1' || (*s)[i] > '9' {
 			return false
 		}
 	}

--- a/internal/handlers/util.go
+++ b/internal/handlers/util.go
@@ -1,6 +1,10 @@
 package handlers
 
-import "strconv"
+import (
+	"crypto/rand"
+	"math/big"
+	"strconv"
+)
 
 // parsePositiveInt parses a query parameter into an int with bounds and default.
 // If invalid or out of range it falls back to defaultValue.
@@ -19,4 +23,36 @@ func parsePositiveInt(raw string, defaultValue, min, max int) int {
 		return max
 	}
 	return v
+}
+
+// GeneratePin returns a numeric PIN of given length using crypto/rand.
+func GeneratePin(length int) string {
+	if length <= 0 {
+		length = 6
+	}
+	const digits = "0123456789"
+	res := make([]byte, length)
+	for i := 0; i < length; i++ {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(digits))))
+		if err != nil {
+			// fallback: deterministic but unlikely; just use '0'
+			res[i] = '0'
+			continue
+		}
+		res[i] = digits[n.Int64()]
+	}
+	return string(res)
+}
+
+// isValidPin6 validates that s is exactly 6 digits.
+func isValidPin6(s *string) bool {
+	if s == nil || len(*s) != 6 {
+		return false
+	}
+	for i := 0; i < 6; i++ {
+		if (*s)[i] < '0' || (*s)[i] > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -649,7 +649,7 @@ paths:
     post:
       operationId: createHumanResource
       summary: 建立人力需求/角色
-      description: 建立一筆人力角色需求紀錄 (含需求人數與技能等資訊)。
+      description: 建立一筆人力角色需求紀錄 (含需求人數與技能等資訊)。可提供 valid_pin 作為後續編輯驗證用的6碼PIN (不會在回應中回傳)；若未提供將由系統自動產生。
       requestBody:
         required: true
         content:
@@ -674,7 +674,7 @@ paths:
     patch:
       operationId: patchHumanResource
       summary: 更新人力需求/角色 (部分欄位)
-      description: 部分更新人力角色需求欄位，只更新傳入欄位。
+      description: 部分更新人力角色需求欄位，只更新傳入欄位。若此紀錄已設定過 valid_pin，必須提供同一個 PIN 才能更新除了 status, is_completed以及headcount_got 的欄位；若尚未設定且本次未提供，系統會自動產生一組 PIN 並允許此次更新。
       parameters:
         - in: path
           name: id
@@ -1970,6 +1970,7 @@ components:
         is_completed: { type: boolean }
         has_medical: { type: boolean, nullable: true }
         pii_date: { type: integer, format: int64, nullable: true, description: 個資同意時間 (Unix Timestamp) }
+        valid_pin: { type: string, nullable: true, description: 編輯用6碼PIN；未提供將自動產生，不會在回應中回傳, minLength: 6, maxLength: 6 }
         role_name: { type: string }
         role_type: { type: string }
         skills: { type: array, items: { type: string } }
@@ -1989,6 +1990,12 @@ components:
     HumanResourcePatch:
       type: object
       properties:
+        valid_pin:
+          type: string
+          nullable: true
+          description: 編輯驗證用6碼PIN；若紀錄尚未有PIN且本次未提供，系統會自動產生
+          minLength: 6
+          maxLength: 6
         org: { type: string }
         address: { type: string }
         phone: { type: string }


### PR DESCRIPTION
HR 表和 Supply 表，新增輸入參數 valid_pin
不輸出。

如果沒有輸入 valid_pin 時將會自動產生。

如果進行修改 PATCH 時沒有帶入 valid_pin 會失敗，除非：
* 對應的  VERIFY_HR_PIN or VERIFY_SUPPLY_PIN 沒有設定為 true (沒有啟用功能)
* 推送 PATCH human_resource 但是只修改 human_resource 的 status, is_completed以及headcount_got 這三個欄位

valid_pin 會以明碼儲存，自動產生的 valid_pin 會是六位數字，沒有檢查是否為特殊狀況 eg: 000000, 333333