### PR TITLE
feat: introduce the valid pin supports

### DIFF
--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -335,6 +335,10 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
             updated_at timestamptz not null default now()
         )`,
 		`create index if not exists idx_ip_denylist_pattern on ip_denylist(pattern)`,
+		// Add valid_pin to human_resources
+		`alter table human_resources add column if not exists valid_pin text`,
+		// Add valid_pin to supplies
+		`alter table supplies add column if not exists valid_pin text`,
 	}
 	for _, s := range stmts {
 		if _, err := pool.Exec(ctx, s); err != nil {

--- a/internal/handlers/human_resource_handlers.go
+++ b/internal/handlers/human_resource_handlers.go
@@ -147,7 +147,7 @@ func join(parts []string, sep string) string {
 }
 
 func (h *Handler) getHumanResourceWithID(id string) (*models.HumanResource, error) {
-	row := h.pool.QueryRow(context.Background(), `select id,org,address,phone,status,is_completed,has_medical,pii_date,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint,role_name,role_type,coalesce(skills,'{}'),coalesce(certifications,'{}'),experience_level,coalesce(language_requirements,'{}'),headcount_need,headcount_got,headcount_unit,role_status,extract(epoch from shift_start_ts)::bigint,extract(epoch from shift_end_ts)::bigint,shift_notes,extract(epoch from assignment_timestamp)::bigint,assignment_count,assignment_notes,total_roles_in_request,completed_roles_in_request,pending_roles_in_request,total_requests,active_requests,completed_requests,cancelled_requests,total_roles,completed_roles,pending_roles,urgent_requests,medical_requests from human_resources where id=$1`, id)
+	row := h.pool.QueryRow(context.Background(), `select id,org,address,phone,status,is_completed,has_medical,pii_date,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint,role_name,role_type,coalesce(skills,'{}'),coalesce(certifications,'{}'),experience_level,coalesce(language_requirements,'{}'),headcount_need,headcount_got,headcount_unit,role_status,extract(epoch from shift_start_ts)::bigint,extract(epoch from shift_end_ts)::bigint,shift_notes,extract(epoch from assignment_timestamp)::bigint,assignment_count,assignment_notes,total_roles_in_request,completed_roles_in_request,pending_roles_in_request,total_requests,active_requests,completed_requests,cancelled_requests,total_roles,completed_roles,pending_roles,urgent_requests,medical_requests,valid_pin from human_resources where id=$1`, id)
 	var hr models.HumanResource
 	var skills, certs, langs []string
 	var hasMedical *bool
@@ -160,7 +160,8 @@ func (h *Handler) getHumanResourceWithID(id string) (*models.HumanResource, erro
 	var totalRoles, completedRoles, pendingRoles *int
 	var urgentReq, medicalReq *int
 	var piiDate *int64
-	if err := row.Scan(&hr.ID, &hr.Org, &hr.Address, &hr.Phone, &hr.Status, &hr.IsCompleted, &hasMedical, &piiDate, &hr.CreatedAt, &hr.UpdatedAt, &hr.RoleName, &hr.RoleType, &skills, &certs, &expLevel, &langs, &hr.HeadcountNeed, &hr.HeadcountGot, &headUnit, &hr.RoleStatus, &shiftStart, &shiftEnd, &shiftNotes, &assignmentTs, &hr.AssignmentCount, &assignmentNotes, &totalRolesInReq, &completedRolesInReq, &pendingRolesInReq, &totalReq, &activeReq, &completedReq, &cancelledReq, &totalRoles, &completedRoles, &pendingRoles, &urgentReq, &medicalReq); err != nil {
+	var validPin *string
+	if err := row.Scan(&hr.ID, &hr.Org, &hr.Address, &hr.Phone, &hr.Status, &hr.IsCompleted, &hasMedical, &piiDate, &hr.CreatedAt, &hr.UpdatedAt, &hr.RoleName, &hr.RoleType, &skills, &certs, &expLevel, &langs, &hr.HeadcountNeed, &hr.HeadcountGot, &headUnit, &hr.RoleStatus, &shiftStart, &shiftEnd, &shiftNotes, &assignmentTs, &hr.AssignmentCount, &assignmentNotes, &totalRolesInReq, &completedRolesInReq, &pendingRolesInReq, &totalReq, &activeReq, &completedReq, &cancelledReq, &totalRoles, &completedRoles, &pendingRoles, &urgentReq, &medicalReq, &validPin); err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, ErrHumanResourceNotFound
 		}
@@ -190,6 +191,7 @@ func (h *Handler) getHumanResourceWithID(id string) (*models.HumanResource, erro
 	hr.PendingRoles = pendingRoles
 	hr.UrgentRequests = urgentReq
 	hr.MedicalRequests = medicalReq
+	hr.ValidPin = validPin
 	return &hr, nil
 }
 

--- a/internal/handlers/util.go
+++ b/internal/handlers/util.go
@@ -20,3 +20,16 @@ func parsePositiveInt(raw string, defaultValue, min, max int) int {
 	}
 	return v
 }
+
+// checkStringPtrEqual checks if the following condition is met:
+// - both are nil
+// - both are not nil and are holding the same value
+func checkStringPtrEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -248,6 +248,7 @@ type HumanResource struct {
 	PendingRoles            *int     `json:"pending_roles"`
 	UrgentRequests          *int     `json:"urgent_requests"`
 	MedicalRequests         *int     `json:"medical_requests"`
+	ValidPin                *string  `json:"valid_pin"`
 }
 
 // Supply represents supplies table row
@@ -258,6 +259,7 @@ type Supply struct {
 	Phone     *string `json:"phone"`
 	Notes     *string `json:"notes"`
 	PiiDate   *int64  `json:"pii_date"`
+	ValidPin  *string `json:"valid_pin"`
 	CreatedAt int64   `json:"created_at"`
 	UpdatedAt int64   `json:"updated_at"`
 }

--- a/internal/utils/valid_pin.go
+++ b/internal/utils/valid_pin.go
@@ -1,0 +1,13 @@
+package utils
+
+import "math/rand"
+
+func GenerateValidPin() string {
+	// generate a 6-digit code using only digits 1-9
+	const digits = "123456789"
+	code := make([]byte, 6)
+	for i := range code {
+		code[i] = digits[rand.Intn(len(digits))]
+	}
+	return string(code)
+}


### PR DESCRIPTION
This pull request introduces a new "valid_pin" field for both `human resources` and `supplies`, adding a layer of authorization for updates and item creation. The changes ensure that only requests with a matching valid pin can modify or add items to these records. Additionally, the code refactors the handlers to centralize record fetching and error handling, and updates the database schema accordingly.

**Authorization and Security Enhancements:**

* Added a `valid_pin` field to both the `human_resources` and `supplies` tables, generated on creation and required for patching and item creation. This pin is now checked for authorization before allowing updates or additions, and is hidden from API responses to clients. [[1]](diffhunk://#diff-311f48b0a3cbb726ac3f19ee0eb90bdeb9ad2014003685c87ef46b6ee920ff86R338-R341) [[2]](diffhunk://#diff-b3002c27104c553d0b77da01342f8f30158fddfdecd3512e42fec95cd1b295c2R301-R308) [[3]](diffhunk://#diff-b3002c27104c553d0b77da01342f8f30158fddfdecd3512e42fec95cd1b295c2R404-R428) [[4]](diffhunk://#diff-d9eb05936eb02a73d9b2ccc1d66268b15a250585511ff006b4f079befdb41ce2R43) [[5]](diffhunk://#diff-d9eb05936eb02a73d9b2ccc1d66268b15a250585511ff006b4f079befdb41ce2R59-R63) [[6]](diffhunk://#diff-d9eb05936eb02a73d9b2ccc1d66268b15a250585511ff006b4f079befdb41ce2L81-R88)

**Handler Refactoring and Error Handling:**

* Refactored handlers to use dedicated getter functions (`getHumanResourceWithID`, `getSupplyWithID`) for fetching records and handling not-found and internal errors in a consistent way. [[1]](diffhunk://#diff-b3002c27104c553d0b77da01342f8f30158fddfdecd3512e42fec95cd1b295c2L146-R151) [[2]](diffhunk://#diff-b3002c27104c553d0b77da01342f8f30158fddfdecd3512e42fec95cd1b295c2L162-R169) [[3]](diffhunk://#diff-b3002c27104c553d0b77da01342f8f30158fddfdecd3512e42fec95cd1b295c2R195-R215) [[4]](diffhunk://#diff-d9eb05936eb02a73d9b2ccc1d66268b15a250585511ff006b4f079befdb41ce2L193-R241)

**Patch and Item Creation Logic Updates:**

* Updated PATCH endpoints for both human resources and supplies to require a matching `valid_pin` before applying updates, returning a forbidden error if the pin does not match. [[1]](diffhunk://#diff-b3002c27104c553d0b77da01342f8f30158fddfdecd3512e42fec95cd1b295c2R404-R428) [[2]](diffhunk://#diff-d9eb05936eb02a73d9b2ccc1d66268b15a250585511ff006b4f079befdb41ce2R272-R304)
* Updated the supply item creation endpoint to require the supply's `valid_pin` for authorization, preventing unauthorized additions.

**Database Migration:**

* Modified the migration logic to add the `valid_pin` column to both `human_resources` and `supplies` tables if it does not already exist.

**Codebase Consistency:**

* Introduced custom error types (`ErrHumanResourceNotFound`, `ErrSupplyNotFound`) for clearer error handling and response codes. [[1]](diffhunk://#diff-b3002c27104c553d0b77da01342f8f30158fddfdecd3512e42fec95cd1b295c2R16-R20) [[2]](diffhunk://#diff-d9eb05936eb02a73d9b2ccc1d66268b15a250585511ff006b4f079befdb41ce2R5-R18)

Let me know if you have questions about how the valid pin works or how the handler changes affect your workflow!