### PR TITLE
fix: fix the id generation part for spam_results

### DIFF
--- a/internal/handlers/human_resource_handlers.go
+++ b/internal/handlers/human_resource_handlers.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
-	"guangfu250923/internal/models"
 	"guangfu250923/internal/middleware"
+	"guangfu250923/internal/models"
 )
 
 // ListHumanResources returns paginated human resource rows


### PR DESCRIPTION
## Description
Since the record ID should be generated by the backend service, not from the LLM ones, the PR adjusted the related implementations to generate the uuidV7 while creating a new record.
