### PR TITLE
feat: add supply_providers related

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -191,6 +191,12 @@ func main() {
 	r.GET("/spam_results/:id", h.GetSpamResult)
 	r.PATCH("/spam_results/:id", middleware.APIKeyVerifier(spamResultAPIKey), h.PatchSpamResult)
 
+	// Supply item providers
+	r.POST("/supply_providers", h.CreateSupplyProvider)
+	r.GET("/supply_providers", h.ListSupplyProviders)
+	r.GET("/supply_providers/:id", h.GetSupplyProvider)
+	r.PATCH("/supply_providers/:id", h.PatchSupplyProvider)
+
 	// Turnstile test endpoint (POST only): echo JSON payload for frontend debugging
 	r.POST("/__test_turnstile", middleware.TurnstileVerifier(), func(c *gin.Context) {
 		var payload any

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -344,10 +344,10 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 		`create index if not exists idx_spam_result_target_id on spam_result(target_id)`,
 		// Supply item providers
 		`create table if not exists supply_providers (
-            id uuid primary key default gen_random_uuid(),
+            id text primary key,
             name text not null,
             phone text not null,
-            supply_item_id uuid not null references supply_items(id) on delete cascade,
+            supply_item_id text not null,
             address text not null,
             note text not null,
             created_at timestamptz not null default now(),

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -342,6 +342,18 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
             validated_at bigint not null
         )`,
 		`create index if not exists idx_spam_result_target_id on spam_result(target_id)`,
+		// Supply item providers
+		`create table if not exists supply_providers (
+            id uuid primary key default gen_random_uuid(),
+            name text not null,
+            phone text not null,
+            supply_item_id uuid not null references supply_items(id) on delete cascade,
+            address text not null,
+            note text not null,
+            created_at timestamptz not null default now(),
+            updated_at timestamptz not null default now()
+        )`,
+		`create index if not exists idx_supply_providers_supply_item_id on supply_providers(supply_item_id)`,
 	}
 	for _, s := range stmts {
 		if _, err := pool.Exec(ctx, s); err != nil {

--- a/internal/handlers/supply_providers.go
+++ b/internal/handlers/supply_providers.go
@@ -1,0 +1,214 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"guangfu250923/internal/models"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+)
+
+type supplyProviderCreateInput struct {
+	Name         string `json:"name" binding:"required"`
+	Phone        string `json:"phone" binding:"required"`
+	SupplyItemID string `json:"supply_item_id" binding:"required"`
+	Address      string `json:"address" binding:"required"`
+	Note         string `json:"note" binding:"required"`
+}
+
+func (h *Handler) CreateSupplyProvider(c *gin.Context) {
+	var in supplyProviderCreateInput
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ctx := context.Background()
+	// Verify supply_item_id exists
+	var exists bool
+	if err := h.pool.QueryRow(ctx, `select exists(select 1 from supply_items where id=$1)`, in.SupplyItemID).Scan(&exists); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if !exists {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found", "reason": "supply item not found"})
+		return
+	}
+
+	var (
+		id               string
+		created, updated int64
+	)
+	err := h.pool.QueryRow(ctx, `insert into supply_providers(name,phone,supply_item_id,address,note) values($1,$2,$3,$4,$5) returning id,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint`,
+		in.Name, in.Phone, in.SupplyItemID, in.Address, in.Note).Scan(&id, &created, &updated)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	out := models.SupplyProvider{
+		ID:           id,
+		Name:         in.Name,
+		Phone:        in.Phone,
+		SupplyItemID: in.SupplyItemID,
+		Address:      in.Address,
+		Note:         in.Note,
+		CreatedAt:    created,
+		UpdatedAt:    updated,
+	}
+	c.JSON(http.StatusCreated, out)
+}
+
+func (h *Handler) ListSupplyProviders(c *gin.Context) {
+	limit := parsePositiveInt(c.Query("limit"), 50, 1, 500)
+	offset := parsePositiveInt(c.Query("offset"), 0, 0, 1000000)
+	supplyItemID := c.Query("supply_item_id")
+	ctx := context.Background()
+
+	var total int
+	var rows pgx.Rows
+	var err error
+	if supplyItemID != "" {
+		h.pool.QueryRow(ctx, `select count(*) from supply_providers where supply_item_id=$1`, supplyItemID).Scan(&total)
+		rows, err = h.pool.Query(ctx, `select id,name,phone,supply_item_id,address,note,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint from supply_providers where supply_item_id=$1 order by updated_at desc limit $2 offset $3`, supplyItemID, limit, offset)
+	} else {
+		h.pool.QueryRow(ctx, `select count(*) from supply_providers`).Scan(&total)
+		rows, err = h.pool.Query(ctx, `select id,name,phone,supply_item_id,address,note,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint from supply_providers order by updated_at desc limit $1 offset $2`, limit, offset)
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	list := []models.SupplyProvider{}
+	for rows.Next() {
+		var sp models.SupplyProvider
+		var created, updated int64
+		if err = rows.Scan(&sp.ID, &sp.Name, &sp.Phone, &sp.SupplyItemID, &sp.Address, &sp.Note, &created, &updated); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		sp.CreatedAt = created
+		sp.UpdatedAt = updated
+		list = append(list, sp)
+	}
+	baseURL := c.Request.URL.Path
+	q := c.Request.URL.Query()
+
+	build := func(off int) string {
+		q.Set("limit", strconv.Itoa(limit))
+		q.Set("offset", strconv.Itoa(off))
+		return baseURL + "?" + q.Encode()
+	}
+	var next *string
+	if offset+limit < total {
+		s := build(offset + limit)
+		next = &s
+	}
+	var prev *string
+	if offset-limit >= 0 {
+		s := build(offset - limit)
+		prev = &s
+	}
+	c.JSON(http.StatusOK, gin.H{"@context": "https://www.w3.org/ns/hydra/context.jsonld", "@type": "Collection", "totalItems": total, "member": list, "limit": limit, "offset": offset, "next": next, "previous": prev})
+}
+
+func (h *Handler) GetSupplyProvider(c *gin.Context) {
+	id := c.Param("id")
+	ctx := context.Background()
+	row := h.pool.QueryRow(ctx, `select id,name,phone,supply_item_id,address,note,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint from supply_providers where id=$1`, id)
+
+	var sp models.SupplyProvider
+	var created, updated int64
+	if err := row.Scan(&sp.ID, &sp.Name, &sp.Phone, &sp.SupplyItemID, &sp.Address, &sp.Note, &created, &updated); err != nil {
+		if err == pgx.ErrNoRows {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	sp.CreatedAt = created
+	sp.UpdatedAt = updated
+	c.JSON(http.StatusOK, sp)
+}
+
+type supplyProviderPatchInput struct {
+	Name         *string `json:"name"`
+	Phone        *string `json:"phone"`
+	SupplyItemID *string `json:"supply_item_id"`
+	Address      *string `json:"address"`
+	Note         *string `json:"note"`
+}
+
+func (h *Handler) PatchSupplyProvider(c *gin.Context) {
+	id := c.Param("id")
+	var in supplyProviderPatchInput
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ctx := context.Background()
+	// If updating supply_item_id, verify it exists
+	if in.SupplyItemID != nil {
+		var exists bool
+		if err := h.pool.QueryRow(ctx, `select exists(select 1 from supply_items where id=$1)`, *in.SupplyItemID).Scan(&exists); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if !exists {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found", "reason": "supply item not found"})
+			return
+		}
+	}
+	// Build dynamic update
+	setParts := []string{}
+	args := []interface{}{}
+	idx := 1
+	add := func(expr string, val interface{}) {
+		setParts = append(setParts, expr+"$"+strconv.Itoa(idx))
+		args = append(args, val)
+		idx++
+	}
+	if in.Name != nil {
+		add("name=", *in.Name)
+	}
+	if in.Phone != nil {
+		add("phone=", *in.Phone)
+	}
+	if in.SupplyItemID != nil {
+		add("supply_item_id=", *in.SupplyItemID)
+	}
+	if in.Address != nil {
+		add("address=", *in.Address)
+	}
+	if in.Note != nil {
+		add("note=", *in.Note)
+	}
+	if len(setParts) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no fields"})
+		return
+	}
+	// always update updated_at
+	setParts = append(setParts, "updated_at=now()")
+	query := "update supply_providers set " + strings.Join(setParts, ",") + " where id=$" + strconv.Itoa(idx) + " returning id,name,phone,supply_item_id,address,note,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint"
+	args = append(args, id)
+	row := h.pool.QueryRow(ctx, query, args...)
+	var sp models.SupplyProvider
+	var created, updated int64
+	if err := row.Scan(&sp.ID, &sp.Name, &sp.Phone, &sp.SupplyItemID, &sp.Address, &sp.Note, &created, &updated); err != nil {
+		if err == pgx.ErrNoRows {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	sp.CreatedAt = created
+	sp.UpdatedAt = updated
+	c.JSON(http.StatusOK, sp)
+}

--- a/internal/handlers/supply_providers.go
+++ b/internal/handlers/supply_providers.go
@@ -75,11 +75,18 @@ func (h *Handler) ListSupplyProviders(c *gin.Context) {
 	var total int
 	var rows pgx.Rows
 	var err error
+
 	if supplyItemID != "" {
-		h.pool.QueryRow(ctx, `select count(*) from supply_providers where supply_item_id=$1`, supplyItemID).Scan(&total)
+		if err := h.pool.QueryRow(ctx, `select count(*) from supply_providers where supply_item_id=$1`, supplyItemID).Scan(&total); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 		rows, err = h.pool.Query(ctx, `select id,name,phone,supply_item_id,address,note,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint from supply_providers where supply_item_id=$1 order by updated_at desc limit $2 offset $3`, supplyItemID, limit, offset)
 	} else {
-		h.pool.QueryRow(ctx, `select count(*) from supply_providers`).Scan(&total)
+		if err := h.pool.QueryRow(ctx, `select count(*) from supply_providers`).Scan(&total); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 		rows, err = h.pool.Query(ctx, `select id,name,phone,supply_item_id,address,note,extract(epoch from created_at)::bigint,extract(epoch from updated_at)::bigint from supply_providers order by updated_at desc limit $1 offset $2`, limit, offset)
 	}
 	if err != nil {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -273,6 +273,18 @@ type SupplyItem struct {
 	Unit          *string `json:"unit"`
 }
 
+// SupplyProvider represents supply_providers table row
+type SupplyProvider struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Phone         string `json:"phone"`
+	SupplyItemID  string `json:"supply_item_id"`
+	Address       string `json:"address"`
+	Note          string `json:"note"`
+	CreatedAt     int64  `json:"created_at"`
+	UpdatedAt     int64  `json:"updated_at"`
+}
+
 // Report represents reports table row
 type Report struct {
 	ID           string  `json:"id"`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1057,6 +1057,68 @@ paths:
         '200': { description: 更新成功, content: { application/json: { schema: { $ref: '#/components/schemas/SupplyItem' } } } }
         '400': { description: 輸入錯誤 }
         '404': { description: 找不到 }
+  /supply_providers:
+    get:
+      operationId: listSupplyProviders
+      summary: 取得物資提供站點清單 (分頁)
+      description: 分頁列出所有物資提供站點，可用 supply_item_id 過濾特定物資項目的站點；採 JSON-LD Collection 格式。
+      parameters:
+        - in: query
+          name: supply_item_id
+          schema: { type: string, format: uuid }
+          description: 過濾指定物資項目的站點
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 500, default: 50 }
+        - in: query
+          name: offset
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        '200': { description: 成功, content: { application/json: { schema: { $ref: '#/components/schemas/SupplyProviderCollection' } } } }
+    post:
+      operationId: createSupplyProvider
+      summary: 建立物資提供站點
+      description: 新增一筆物資提供站點資料，必須關聯到既有的物資項目 (supply_item_id)。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SupplyProviderCreate' }
+      responses:
+        '201': { description: 建立成功, content: { application/json: { schema: { $ref: '#/components/schemas/SupplyProvider' } } } }
+        '400': { description: 輸入錯誤 }
+        '404': { description: 關聯的物資項目不存在 }
+  /supply_providers/{id}:
+    get:
+      operationId: getSupplyProvider
+      summary: 取得單一物資提供站點
+      description: 依物資提供站點 UUID 取得其詳細資訊。
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200': { description: 成功, content: { application/json: { schema: { $ref: '#/components/schemas/SupplyProvider' } } } }
+        '404': { description: 找不到 }
+    patch:
+      operationId: patchSupplyProvider
+      summary: 更新物資提供站點 (部分欄位)
+      description: 部分更新物資提供站點欄位；若更新 supply_item_id 則驗證其存在性，並自動更新 updated_at。
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SupplyProviderPatch' }
+      responses:
+        '200': { description: 更新成功, content: { application/json: { schema: { $ref: '#/components/schemas/SupplyProvider' } } } }
+        '400': { description: 輸入錯誤 }
+        '404': { description: 找不到 }
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -2360,6 +2422,42 @@ components:
             member:
               type: array
               items: { $ref: '#/components/schemas/SupplyItem' }
+    SupplyProvider:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+        phone: { type: string }
+        supply_item_id: { type: string, format: uuid }
+        address: { type: string }
+        note: { type: string }
+        created_at: { type: integer, format: int64 }
+        updated_at: { type: integer, format: int64 }
+    SupplyProviderCreate:
+      type: object
+      required: [name,phone,supply_item_id,address,note]
+      properties:
+        name: { type: string }
+        phone: { type: string }
+        supply_item_id: { type: string, format: uuid }
+        address: { type: string }
+        note: { type: string }
+    SupplyProviderPatch:
+      type: object
+      properties:
+        name: { type: string, nullable: true }
+        phone: { type: string, nullable: true }
+        supply_item_id: { type: string, format: uuid, nullable: true }
+        address: { type: string, nullable: true }
+        note: { type: string, nullable: true }
+    SupplyProviderCollection:
+      allOf:
+        - $ref: '#/components/schemas/CollectionBase'
+        - type: object
+          properties:
+            member:
+              type: array
+              items: { $ref: '#/components/schemas/SupplyProvider' }
     Report:
       type: object
       properties:


### PR DESCRIPTION
## Description

This pull request adds full support for managing "supply providers" (物資提供站點) in the application. It introduces a new database table, API endpoints, data model, and OpenAPI documentation for creating, listing, retrieving, and updating supply provider records, each of which is associated with a supply item.

**API and Handler Implementation:**

* Added new handler functions in `internal/handlers/supply_providers.go` for creating, listing (with pagination and filtering), retrieving, and patching supply provider records. These handlers validate input, ensure referenced supply items exist, and support partial updates.
* Registered new RESTful routes in `cmd/server/main.go` for the supply provider resource (`/supply_providers` and `/supply_providers/:id`).

**Database and Model Changes:**

* Introduced a new `supply_providers` table in the migration logic (`internal/db/migrate.go`), with relevant fields and a foreign key to `supply_items`, plus an index for efficient queries.
* Added the `SupplyProvider` struct to the application data models in `internal/models/models.go` to represent table rows and API responses.

**API Documentation:**

* Updated `openapi.yaml` to document the new endpoints for supply providers, including request/response schemas and collection format.
* Defined new OpenAPI schemas for `SupplyProvider`, `SupplyProviderCreate`, `SupplyProviderPatch`, and `SupplyProviderCollection` to support validation and client generation.

## Reference
https://github.com/carolchu1208/Hualian-Typhoon-Rescue-Site-Backend-Team/blob/main/table_spec.md#supply_providers